### PR TITLE
Remove superfluous options

### DIFF
--- a/clients/samdrucker.sh
+++ b/clients/samdrucker.sh
@@ -54,4 +54,4 @@ repo=`/usr/sbin/pkg -vv | $GREP  url | $CUT -f2 -d \"`
 
 payload=`$JO -p name=$hostname os=$uname version=$version repo=$repo $pkg_args`
 
-$CURL $CURL_OPTIONS -d "$SAMDRUCKER_ARG=$payload" -H "Content-Type: application/x-www-form-urlencoded" -X POST $SAMDRUCKER_URL
+$CURL $CURL_OPTIONS -d "$SAMDRUCKER_ARG=$payload" $SAMDRUCKER_URL


### PR DESCRIPTION
Unless you want to explicitly specify the options I’ve removed (though they’re redundant as `-d` means POST with the specific content-type), I think this makes the command clearer.